### PR TITLE
Bugfix: Add to LD_LIBRARY_PATH

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
   - template: .ci/esy-build-steps.yml
 
 - job: Windows
+  timeoutInMinutes: 0
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
         "ONIGURUMA_LIB_PATH": {
             "val": "#{self.lib}",
             "scope": "global"
+        },
+        "CAML_LD_LIBRARY_PATH": {
+            "val": "#{self.lib : $CAML_LD_LIBRARY_PATH}",
+            "scope": "global"
         }
     }
   },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
             "val": "#{self.lib}",
             "scope": "global"
         },
-        "CAML_LD_LIBRARY_PATH": {
-            "val": "#{self.lib : $CAML_LD_LIBRARY_PATH}",
+        "LD_LIBRARY_PATH": {
+            "val": "#{self.lib : $LD_LIBRARY_PATH}",
             "scope": "global"
         }
     }


### PR DESCRIPTION
On some platforms, we'd get an error message when running applications that depended on Oniguruma:

```
error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
```

This fixes it by adding `libonig.so.2` to the `LD_LIBRARY_PATH` environment variable, which will help the runtime locate the dependency.